### PR TITLE
Fix helm build dependency issue

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: 🐳 Helm dependency
       run: |
-        yq --indent 0 '.dependencies | map(["helm", "repo", "add", .name, .repository] | join(" ")) | .[]' ./helm/Chart.lock  | sh --
+        yq --indent 0 '.dependencies | map(select(.repository | test("^oci:") | not)) | map(["helm", "repo", "add", .name, .repository] | join(" ")) | .[]' ./helm/Chart.lock | sh --
         helm dependency build ./helm/
 
     - name: Tag docker image in Helm Chart values.yaml


### PR DESCRIPTION
Addresses
- Fix Build dependency issue

## Changes
- Filter out the oci repo while building the helm subchart

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] flake8 issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
