### PR TITLE
Fix historical pdc gdacs extraction.

### DIFF
--- a/main/celery.py
+++ b/main/celery.py
@@ -19,6 +19,10 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 # Default autodiscover (Looks at apps/*/tasks.py)
 app.autodiscover_tasks()
 app.conf.task_queues = {
+    "default": {
+        "exchange": "default",
+        "routing_key": "default",
+    },
     "extraction": {
         "exchange": "extraction",
         "routing_key": "extraction",


### PR DESCRIPTION
## Changes
  - Fix/historical gdacs pdc

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] linter issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
