### PR TITLE
emdat: Add file as input inplace of raw data in transformer

### DIFF
--- a/apps/etl/transform/sources/emdat.py
+++ b/apps/etl/transform/sources/emdat.py
@@ -1,10 +1,10 @@
-import json
 import logging
 
 from pystac_monty.sources.emdat import EMDATDataSource, EMDATTransformer
 
 from apps.etl.models import ExtractionData
 from apps.etl.transform.sources.handler import BaseTransformerHandler
+from apps.etl.utils import write_into_temp_file
 from main.celery import app
 
 logger = logging.getLogger(__name__)
@@ -16,12 +16,13 @@ class EMDATTransformHandler(BaseTransformerHandler[EMDATTransformer, EMDATDataSo
 
     @classmethod
     def get_schema_data(cls, extraction_obj: ExtractionData):
-        with extraction_obj.resp_data.open() as file_data:
-            data = json.loads(file_data.read())
+        with extraction_obj.resp_data.open("rb") as f:
+            data = f.read()
+        data_file = write_into_temp_file(data)
 
         return cls.transformer_schema(
             source_url=extraction_obj.url,
-            data=data,
+            data=data_file.name,
         )
 
     @staticmethod

--- a/apps/etl/transform/sources/emdat.py
+++ b/apps/etl/transform/sources/emdat.py
@@ -1,5 +1,6 @@
 import logging
 
+from pystac_monty.sources.common import DataType, File
 from pystac_monty.sources.emdat import EMDATDataSource, EMDATTransformer
 
 from apps.etl.models import ExtractionData
@@ -20,10 +21,9 @@ class EMDATTransformHandler(BaseTransformerHandler[EMDATTransformer, EMDATDataSo
             data = f.read()
         data_file = write_into_temp_file(data)
 
-        return cls.transformer_schema(
-            source_url=extraction_obj.url,
-            data=data_file.name,
-        )
+        data_source = {"source_url": extraction_obj.url, "source_data": File(path=data_file.name, data_type=DataType.FILE)}
+
+        return cls.transformer_schema(data_source)
 
     @staticmethod
     @app.task


### PR DESCRIPTION
## Changes
  - add file as input inplace of data in transformer for Emdat

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] linter issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
