### PR TITLE
Gdacs: Send multiple file as input in gdacs trnsformer.

### DIFF
--- a/apps/etl/transform/sources/gdacs.py
+++ b/apps/etl/transform/sources/gdacs.py
@@ -1,13 +1,14 @@
-import json
 import logging
 
+from pystac_monty.sources.common import DataType, File, GdacsDataSourceType, GdacsEpisodes, GenericDataSource
 from pystac_monty.sources.gdacs import (
-    GDACSDataSource,
     GDACSDataSourceType,
+    GDACSDataSourceV3,
     GDACSTransformer,
 )
 
 from apps.etl.transform.sources.handler import BaseTransformerHandler
+from apps.etl.utils import write_into_temp_file
 from main.celery import app
 
 logger = logging.getLogger(__name__)
@@ -15,29 +16,54 @@ logger = logging.getLogger(__name__)
 # FIXME: start_end_handler base zzz
 
 
-class GDACSTransformHandler(BaseTransformerHandler[GDACSTransformer, GDACSDataSource]):
+class GDACSTransformHandler(BaseTransformerHandler[GDACSTransformer, GDACSDataSourceV3]):
     transformer_class = GDACSTransformer
-    transformer_schema = GDACSDataSource
+    transformer_schema = GDACSDataSourceV3
 
     @classmethod
     def get_schema_data(cls, extraction_object):
-        data = extraction_object.resp_data.read()
+        with extraction_object.resp_data.open("rb") as f:
+            file_content = f.read()
+        data_file = write_into_temp_file(file_content)
+
         episodes = []
         event_objects = extraction_object.child_extractions.all()
         for episode_obj in event_objects:
-            episodes_data_dict = {}
-            event_episode_data = episode_obj.resp_data.read()
-            episodes_data_dict[GDACSDataSourceType.EVENT] = (episode_obj.url, json.loads(event_episode_data))
-            geometry_objects = episode_obj.child_extractions.all()
+            with episode_obj.resp_data.open("rb") as f:
+                file_content = f.read()
+            episode_data_temp_file = write_into_temp_file(file_content)
 
-            for geometry_detail in geometry_objects:
-                geometry_episode_data = geometry_detail.resp_data.read()
-                episodes_data_dict[GDACSDataSourceType.GEOMETRY] = (geometry_detail.url, json.loads(geometry_episode_data))
+            event_episode_data = GdacsEpisodes(
+                type=GDACSDataSourceType.EVENT,
+                data=GenericDataSource(
+                    source_url=episode_obj.url, data_source=File(path=episode_data_temp_file.name, data_type=DataType.FILE)
+                ),
+            )
+            geometry_object = episode_obj.child_extractions.all().first()
 
-            episodes.append(episodes_data_dict)
-        return cls.transformer_schema(source_url=extraction_object.url, data=json.loads(data), episodes=episodes)
+            with geometry_object.resp_data.open("rb") as f:
+                file_content = f.read()
+            geometry_detail_temp_file = write_into_temp_file(file_content)
+            geometry_episode_data = GdacsEpisodes(
+                type=GDACSDataSourceType.GEOMETRY,
+                data=GenericDataSource(
+                    source_url=geometry_object.url,
+                    data_source=File(path=geometry_detail_temp_file.name, data_type=DataType.FILE),
+                ),
+            )
+
+            episode_data_tuple = (event_episode_data, geometry_episode_data)
+            episodes.append(episode_data_tuple)
+
+        return cls.transformer_schema(
+            data=GdacsDataSourceType(
+                source_url=extraction_object.url,
+                event_data=File(path=data_file.name, data_type=DataType.FILE),
+                episodes=episodes,
+            )
+        )
 
     @staticmethod
-    @app.task
+    @app.task(rate_limit="50/m")
     def task(extraction_id):
         GDACSTransformHandler().handle_transformation(extraction_id)

--- a/apps/etl/transform/sources/glide.py
+++ b/apps/etl/transform/sources/glide.py
@@ -1,6 +1,6 @@
 import json
 
-from pystac_monty.sources.common import DataType, File
+from pystac_monty.sources.common import DataType, File, GenericDataSource
 from pystac_monty.sources.glide import GlideDataSource, GlideTransformer
 
 from apps.etl.models import ExtractionData
@@ -18,9 +18,13 @@ class GlideTransformHandler(BaseTransformerHandler[GlideTransformer, GlideDataSo
         with extraction_obj.resp_data.open("rb") as f:
             data = f.read()
         data_file = write_into_temp_file(data)
-        data_source = {"source_url": extraction_obj.url, "source_data": File(path=data_file.name, data_type=DataType.FILE)}
 
-        return cls.transformer_schema(data_source)
+        return cls.transformer_schema(
+            data=GenericDataSource(
+                source_url=extraction_obj.url,
+                data_source=File(path=data_file.name, data_type=DataType.FILE),
+            )
+        )
 
     @staticmethod
     @app.task


### PR DESCRIPTION
## Changes
  - Send multiple file as input in gdacs trnsformer.


## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] linter issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
