### PR TITLE
Temporarily stop the retrigger cronjob

### DIFF
--- a/main/cronjobs.py
+++ b/main/cronjobs.py
@@ -65,10 +65,10 @@ SCHEDULES: dict[str, CronJob] = {
         task="apps.etl.etl_tasks.pdc.extract_and_transform_pdc_latest_data",
         schedule=crontab(hour=16, minute=0),
     ),
-    "trigger_pending_extraction": CronJob(
-        task="apps.etl.tasks.trigger_pending_extraction",
-        schedule=crontab(hour="23,5", minute=30),
-    ),
+    # "trigger_pending_extraction": CronJob(
+    #     task="apps.etl.tasks.trigger_pending_extraction",
+    #     schedule=crontab(hour="23,5", minute=30),
+    # ),
     "load_data_to_stac": CronJob(
         task="apps.etl.tasks.load_data",
         schedule=crontab(hour="*", minute=0),  # Every hour


### PR DESCRIPTION
Temporary disable the retrigger cronjob for deployment. This PR shouldn't be merged.

## Changes

* Detailed list or prose of changes
* Breaking changes
* Changes to configurations

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] n+1 queries
- [ ] linter issues
- [ ] `print`
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] tests
