### PR TITLE
Feat(celery): add the celery lock to load the STAC items to STAC server

### DIFF
--- a/apps/etl/extraction/sources/desinventar/extract.py
+++ b/apps/etl/extraction/sources/desinventar/extract.py
@@ -8,7 +8,7 @@ import pydantic
 from apps.etl.extraction.sources.base.handler import BaseExtractionV2
 from apps.etl.models import ExtractionData
 from apps.etl.transform.sources.desinventar import DesinventarTransformHandler
-from main.celery import app
+from main.celery import CeleryQueue, app
 from main.logging import log_extra
 from utils.celery import RetryableTask
 
@@ -69,9 +69,6 @@ class DesInventarExtraction(BaseExtractionV2[DesInventarExtractionMetadata]):
                 typing.assert_never(handler_type)
 
     @staticmethod
-    @app.task(
-        bind=True,
-        base=RetryableTask,
-    )
+    @app.task(bind=True, base=RetryableTask, queue=CeleryQueue.EXTRACTION)
     def task(celery_task, extraction_id):
         DesInventarExtraction(celery_task, extraction_id).handle()

--- a/apps/etl/extraction/sources/emdat/extract.py
+++ b/apps/etl/extraction/sources/emdat/extract.py
@@ -63,7 +63,7 @@ class EmdatExtraction(BaseExtractionV2[EmdatExtractionMetadata]):
     @app.task(
         bind=True,
         base=RetryableTask,
-        queue=CeleryQueue.DEFAULT,
+        queue=CeleryQueue.EXTRACTION,
     )
     def task(celery_task: Task, extraction_id: int) -> int:
         EmdatExtraction(celery_task, extraction_id).handle()

--- a/apps/etl/extraction/sources/gdacs/extract.py
+++ b/apps/etl/extraction/sources/gdacs/extract.py
@@ -10,7 +10,7 @@ from celery import chain, chord
 from apps.etl.extraction.sources.base.handler import BaseExtractionV2
 from apps.etl.models import ExtractionData
 from apps.etl.transform.sources.gdacs import GDACSTransformHandler
-from main.celery import app
+from main.celery import CeleryQueue, app
 from main.configs import etl_config
 from main.logging import log_extra
 from utils.celery import RetryableTask
@@ -261,6 +261,7 @@ class GdacsExtraction(BaseExtractionV2[GdacsExtractionMetadata]):
     @app.task(
         bind=True,
         base=RetryableTask,
+        queue=CeleryQueue.EXTRACTION,
         rate_limit="100/m",
     )
     def task(celery_task, extraction_id, retrigger: bool = False) -> int:

--- a/apps/etl/extraction/sources/gfd/extract.py
+++ b/apps/etl/extraction/sources/gfd/extract.py
@@ -153,6 +153,6 @@ class GFDExtraction(BaseExtractionV2[GFDExtractionMetadata]):
                 typing.assert_never(handler_type)
 
     @staticmethod
-    @app.task(bind=True, base=RetryableTask, queue=CeleryQueue.DEFAULT)
+    @app.task(bind=True, base=RetryableTask, queue=CeleryQueue.EXTRACTION)
     def task(celery_task, extraction_id):  # type: ignore[reportIncompatibleMethodOverride]
         GFDExtraction(celery_task, extraction_id).handle()

--- a/apps/etl/extraction/sources/gidd/extract.py
+++ b/apps/etl/extraction/sources/gidd/extract.py
@@ -56,6 +56,6 @@ class GIDDExtraction(BaseExtractionV2[GIDDExtractionMetadata]):
                 typing.assert_never(handler_type)
 
     @staticmethod
-    @app.task(bind=True, base=RetryableTask, queue=CeleryQueue.DEFAULT)
+    @app.task(bind=True, base=RetryableTask, queue=CeleryQueue.EXTRACTION)
     def task(celery_task, extraction_id):  # type: ignore[reportIncompatibleMethodOverride]
         GIDDExtraction(celery_task, extraction_id).handle()

--- a/apps/etl/extraction/sources/glide/extract.py
+++ b/apps/etl/extraction/sources/glide/extract.py
@@ -8,7 +8,7 @@ from celery import Task
 from apps.etl.extraction.sources.base.handler import BaseExtractionV2
 from apps.etl.models import ExtractionData
 from apps.etl.transform.sources.glide import GlideTransformHandler
-from main.celery import app
+from main.celery import CeleryQueue, app
 from main.logging import log_extra
 from utils.celery import RetryableTask
 
@@ -65,6 +65,7 @@ class GlideExtraction(BaseExtractionV2[GlideExtractionMetadata]):
     @app.task(
         bind=True,
         base=RetryableTask,
+        queue=CeleryQueue.EXTRACTION,
     )
     def task(celery_task: Task, extraction_id: int) -> int:
         GlideExtraction(celery_task, extraction_id).handle()

--- a/apps/etl/extraction/sources/idu/extract.py
+++ b/apps/etl/extraction/sources/idu/extract.py
@@ -55,6 +55,6 @@ class IDUExtraction(BaseExtractionV2[IDUExtractionMetadata]):
                 typing.assert_never(handler_type)
 
     @staticmethod
-    @app.task(bind=True, base=RetryableTask, queue=CeleryQueue.DEFAULT)
+    @app.task(bind=True, base=RetryableTask, queue=CeleryQueue.EXTRACTION)
     def task(celery_task, extraction_id):  # type: ignore[reportIncompatibleMethodOverride]
         IDUExtraction(celery_task, extraction_id).handle()

--- a/apps/etl/extraction/sources/ifrc_event/extract.py
+++ b/apps/etl/extraction/sources/ifrc_event/extract.py
@@ -13,7 +13,7 @@ from apps.etl.extraction.sources.base.handler import BaseExtraction, BaseExtract
 from apps.etl.extraction.sources.base.utils import manage_duplicate_file_content
 from apps.etl.models import ExtractionData
 from apps.etl.transform.sources.ifrc_event import IFRCEventTransformHandler
-from main.celery import app
+from main.celery import CeleryQueue, app
 from main.configs import etl_config
 from main.logging import log_extra
 from utils.celery import RetryableTask
@@ -194,9 +194,6 @@ class IFRCEventExtractionV2(BaseExtractionV2[IFRCExtractionMetadata]):
                 typing.assert_never(handler_type)
 
     @staticmethod
-    @app.task(
-        bind=True,
-        base=RetryableTask,
-    )
+    @app.task(bind=True, base=RetryableTask, queue=CeleryQueue.EXTRACTION)
     def task(celery_task, extraction_id):
         IFRCEventExtractionV2(celery_task, extraction_id).handle()

--- a/apps/etl/extraction/sources/noaa_IBTrACS/extract.py
+++ b/apps/etl/extraction/sources/noaa_IBTrACS/extract.py
@@ -7,7 +7,7 @@ import pydantic
 from apps.etl.extraction.sources.base.handler import BaseExtractionV2
 from apps.etl.models import ExtractionData
 from apps.etl.transform.sources.noaa_ibtracs import IbtracsTransformHandler
-from main.celery import app
+from main.celery import CeleryQueue, app
 from main.logging import log_extra
 from utils.celery import RetryableTask
 
@@ -57,6 +57,7 @@ class IBTrACSExtraction(BaseExtractionV2[IBTrACSExtractionMetadata]):
     @app.task(
         bind=True,
         base=RetryableTask,
+        queue=CeleryQueue.EXTRACTION,
     )
     def task(celery_task, extraction_id):  # type: ignore[reportIncompatibleMethodOverride]
         IBTrACSExtraction(celery_task, extraction_id).handle()

--- a/apps/etl/load/sources/base.py
+++ b/apps/etl/load/sources/base.py
@@ -15,7 +15,7 @@ logger = get_task_logger(__name__)
 HEADERS = {"Content-Type": "application/json"}
 
 
-def load_collections(*, eoapi_domain: str, skip_collection_create: bool) -> list[str]:
+def load_collections(*, eoapi_domain: str, skip_collection_create: bool, timeout: int = 30) -> list[str]:
     """
     Create missing collections in eoAPI
     """
@@ -27,7 +27,7 @@ def load_collections(*, eoapi_domain: str, skip_collection_create: bool) -> list
     # get the length from the ITEM_TYPE_COLLEcTION_ID_MAP.keys() but the issue is
     # there are more collections in the eoAPI than required which fails to get
     # the genuine collection ids using the below request.
-    response = requests.get(f"{url}?limit=50", headers=HEADERS)
+    response = requests.get(f"{url}?limit=50", headers=HEADERS, timeout=timeout)
 
     if response.status_code != 200:
         logger.error(
@@ -54,6 +54,7 @@ def load_collections(*, eoapi_domain: str, skip_collection_create: bool) -> list
             json={
                 "id": collection_id,
             },
+            timeout=timeout,
         )
         if response.status_code == 200:
             remote_collections.append(collection_id)

--- a/apps/etl/tasks.py
+++ b/apps/etl/tasks.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 @shared_task
 def load_data():
     """Load the data to STAC eoAPI server"""
-    with CeleryLock.redis_lock(CeleryLock.Key.LOAD_TO_STAC, lock_expire=TimeConstants.SECONDS_IN_A_HOUR) as acquired:
+    with CeleryLock.redis_lock(CeleryLock.Key.LOAD_TO_STAC, lock_expire=TimeConstants.SECONDS_IN_SIX_HOURS) as acquired:
         if not acquired:
             logger.warning("Load to STAC server already running")
             return

--- a/apps/etl/tasks.py
+++ b/apps/etl/tasks.py
@@ -9,6 +9,8 @@ from apps.etl.extraction.sources.pdc.extract import PDCExtractionV2
 from apps.etl.extraction.sources.usgs.extract import USGSExtraction
 from apps.etl.models import ExtractionData
 from apps.etl.mutations import source_extraction_map
+from main.cache import CeleryLock
+from main.cronjobs import TimeConstants
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +18,12 @@ logger = logging.getLogger(__name__)
 @shared_task
 def load_data():
     """Load the data to STAC eoAPI server"""
-    call_command("load_data_to_stac")
+    with CeleryLock.redis_lock(CeleryLock.Key.LOAD_TO_STAC, lock_expire=TimeConstants.SECONDS_IN_A_HOUR) as acquired:
+        if not acquired:
+            logger.warning("Load to STAC server already running")
+            return
+
+        call_command("load_data_to_stac")
 
 
 @shared_task

--- a/apps/etl/tests/common/base_settings_test.py
+++ b/apps/etl/tests/common/base_settings_test.py
@@ -1,0 +1,15 @@
+from django.conf import settings
+
+TEST_CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": settings.TEST_CACHE_REDIS_URL,
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        },
+        "KEY_PREFIX": "test_dj_cache-",
+    },
+    "local-memory": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    },
+}

--- a/apps/etl/tests/sources/desinventar_test.py
+++ b/apps/etl/tests/sources/desinventar_test.py
@@ -9,6 +9,7 @@ from pystac_monty.sources.common import MontyDataTransformer
 
 from apps.etl.etl_tasks.desinventar import ext_and_transform_desinventar_historical_data
 from apps.etl.models import ExtractionData, PyStacLoadData, Transform
+from apps.etl.tests.common.base_settings_test import TEST_CACHES
 from apps.etl.utils import remove_ignored_keys
 from main.configs import etl_config
 
@@ -26,10 +27,7 @@ TEST_CASES = [
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("case", TEST_CASES)
-@override_settings(
-    TRANSFORM_SUCCESS_RATE=10,
-    CELERY_TASK_ALWAYS_EAGER=True,
-)
+@override_settings(TRANSFORM_SUCCESS_RATE=10, CELERY_TASK_ALWAYS_EAGER=True, CACHES=TEST_CACHES)
 def test_handle_extraction_various_desinventar_files(case):
     input_filename = case["input"]
     expected_filename = case["expected"]

--- a/apps/etl/tests/sources/emdat_test.py
+++ b/apps/etl/tests/sources/emdat_test.py
@@ -11,6 +11,7 @@ from pystac_monty.sources.common import MontyDataTransformer
 
 from apps.etl.etl_tasks.emdat import ext_and_transform_emdat_latest_data
 from apps.etl.models import ExtractionData, PyStacLoadData, Transform
+from apps.etl.tests.common.base_settings_test import TEST_CACHES
 from apps.etl.utils import remove_ignored_keys
 from main.configs import etl_config
 
@@ -29,10 +30,7 @@ TEST_CASES = [
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("case", TEST_CASES)
-@override_settings(
-    TRANSFORM_SUCCESS_RATE=20,
-    CELERY_TASK_ALWAYS_EAGER=True,
-)
+@override_settings(TRANSFORM_SUCCESS_RATE=20, CELERY_TASK_ALWAYS_EAGER=True, CACHES=TEST_CACHES)
 def test_handle_extraction_various_emdat_files(case):
     input_filename = case["input"]
     fixed_filename = case["expected"]

--- a/apps/etl/tests/sources/gdacs_test.py
+++ b/apps/etl/tests/sources/gdacs_test.py
@@ -10,6 +10,7 @@ from pystac_monty.sources.common import MontyDataTransformer
 from apps.etl.etl_tasks.gdacs import ext_and_transform_gdacs_historical_data
 from apps.etl.etl_tasks.segment_gdacs import deep_dive
 from apps.etl.models import ExtractionData, PyStacLoadData, Transform
+from apps.etl.tests.common.base_settings_test import TEST_CACHES
 from apps.etl.utils import remove_ignored_keys
 
 MontyDataTransformer.base_collection_url = "/code/libs/pystac-monty/monty-stac-extension/examples"
@@ -21,7 +22,7 @@ step3_episode_url = "https://www.gdacs.org/gdacsapi/api/events/getepisodedata?ev
 step4_geom_url = "https://www.gdacs.org/gdacsapi/api/polygons/getgeometry?eventtype=EQ&eventid=1466272&episodeid=1620062"
 
 
-@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True, CACHES=TEST_CACHES)
 @pytest.mark.django_db
 def test_handle_gdacs_extraction_with_mocked_request():
     """

--- a/apps/etl/tests/sources/gfd_test.py
+++ b/apps/etl/tests/sources/gfd_test.py
@@ -10,6 +10,7 @@ from pystac_monty.sources.common import MontyDataTransformer
 
 from apps.etl.etl_tasks.gfd import ext_and_transform_gfd_historical_data
 from apps.etl.models import ExtractionData, PyStacLoadData, Transform
+from apps.etl.tests.common.base_settings_test import TEST_CACHES
 from apps.etl.utils import remove_ignored_keys
 
 # Set base_collection_url
@@ -27,10 +28,7 @@ TEST_CASES = [
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("case", TEST_CASES)
-@override_settings(
-    TRANSFORM_SUCCESS_RATE=20,
-    CELERY_TASK_ALWAYS_EAGER=True,
-)
+@override_settings(TRANSFORM_SUCCESS_RATE=20, CELERY_TASK_ALWAYS_EAGER=True, CACHES=TEST_CACHES)
 def test_handle_extraction_various_gfd_files(case):
     input_filename = case["input"]
     fixed_filename = case["expected"]

--- a/apps/etl/tests/sources/gidd_test.py
+++ b/apps/etl/tests/sources/gidd_test.py
@@ -11,6 +11,7 @@ from pystac_monty.sources.common import MontyDataTransformer
 
 from apps.etl.etl_tasks.gidd import ext_and_transform_gidd_latest_data
 from apps.etl.models import ExtractionData, PyStacLoadData, Transform
+from apps.etl.tests.common.base_settings_test import TEST_CACHES
 from apps.etl.utils import remove_ignored_keys
 from main.configs import etl_config
 
@@ -29,10 +30,7 @@ TEST_CASES = [
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("case", TEST_CASES)
-@override_settings(
-    TRANSFORM_SUCCESS_RATE=20,
-    CELERY_TASK_ALWAYS_EAGER=True,
-)
+@override_settings(TRANSFORM_SUCCESS_RATE=20, CELERY_TASK_ALWAYS_EAGER=True, CACHES=TEST_CACHES)
 def test_handle_extraction_various_gidd_files(case):
     input_filename = case["input"]
     fixed_filename = case["expected"]

--- a/apps/etl/tests/sources/glide_test.py
+++ b/apps/etl/tests/sources/glide_test.py
@@ -11,6 +11,7 @@ from pystac_monty.sources.common import MontyDataTransformer
 
 from apps.etl.etl_tasks.glide import ext_and_transform_glide_latest_data
 from apps.etl.models import ExtractionData, PyStacLoadData, Transform
+from apps.etl.tests.common.base_settings_test import TEST_CACHES
 from apps.etl.utils import remove_ignored_keys
 from main.configs import etl_config
 
@@ -29,10 +30,7 @@ TEST_CASES = [
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("case", TEST_CASES)
-@override_settings(
-    TRANSFORM_SUCCESS_RATE=20,
-    CELERY_TASK_ALWAYS_EAGER=True,
-)
+@override_settings(TRANSFORM_SUCCESS_RATE=20, CELERY_TASK_ALWAYS_EAGER=True, CACHES=TEST_CACHES)
 def test_handle_extraction_various_gidd_files(case):
     input_filename = case["input"]
     fixed_filename = case["expected"]

--- a/apps/etl/tests/sources/ibtracs_test.py
+++ b/apps/etl/tests/sources/ibtracs_test.py
@@ -10,6 +10,7 @@ from pystac_monty.sources.common import MontyDataTransformer
 
 from apps.etl.etl_tasks.noaa_IBTrACS import ext_and_transform_ibtracs_latest_data
 from apps.etl.models import ExtractionData, PyStacLoadData, Transform
+from apps.etl.tests.common.base_settings_test import TEST_CACHES
 from apps.etl.utils import remove_ignored_keys
 from main.configs import etl_config
 
@@ -28,10 +29,7 @@ TEST_CASES = [
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("case", TEST_CASES)
-@override_settings(
-    TRANSFORM_SUCCESS_RATE=20,
-    CELERY_TASK_ALWAYS_EAGER=True,
-)
+@override_settings(TRANSFORM_SUCCESS_RATE=20, CELERY_TASK_ALWAYS_EAGER=True, CACHES=TEST_CACHES)
 def test_handle_extraction_various_ibtracs_files(case):
     input_filename = case["input"]
     fixed_filename = case["expected"]

--- a/apps/etl/tests/sources/idus_test.py
+++ b/apps/etl/tests/sources/idus_test.py
@@ -11,6 +11,7 @@ from pystac_monty.sources.common import MontyDataTransformer
 
 from apps.etl.etl_tasks.idu import ext_and_transform_idu_latest_data
 from apps.etl.models import ExtractionData, PyStacLoadData, Transform
+from apps.etl.tests.common.base_settings_test import TEST_CACHES
 from apps.etl.utils import remove_ignored_keys
 from main.configs import etl_config
 
@@ -29,10 +30,7 @@ TEST_CASES = [
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("case", TEST_CASES)
-@override_settings(
-    TRANSFORM_SUCCESS_RATE=20,
-    CELERY_TASK_ALWAYS_EAGER=True,
-)
+@override_settings(TRANSFORM_SUCCESS_RATE=20, CELERY_TASK_ALWAYS_EAGER=True, CACHES=TEST_CACHES)
 def test_handle_extraction_various_idu_files(case):
     input_filename = case["input"]
     fixed_filename = case["expected"]

--- a/apps/etl/tests/sources/ifrc_test.py
+++ b/apps/etl/tests/sources/ifrc_test.py
@@ -11,6 +11,7 @@ from pystac_monty.sources.common import MontyDataTransformer
 
 from apps.etl.etl_tasks.ifrc_event import ext_and_transform_ifrcevent_latest_data
 from apps.etl.models import ExtractionData, PyStacLoadData, Transform
+from apps.etl.tests.common.base_settings_test import TEST_CACHES
 from apps.etl.utils import remove_ignored_keys
 
 # Set base_collection_url
@@ -28,7 +29,7 @@ TEST_CASES = [
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("case", TEST_CASES)
-@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True, CACHES=TEST_CACHES)
 def test_handle_extraction_various_ifrc_files(case):
     input_filename = case["input"]
     fixed_filename = case["expected"]

--- a/apps/etl/tests/sources/pdc_test.py
+++ b/apps/etl/tests/sources/pdc_test.py
@@ -9,6 +9,7 @@ from pystac_monty.sources.common import MontyDataTransformer
 
 from apps.etl.etl_tasks.pdc import extract_and_transform_pdc_latest_data
 from apps.etl.models import ExtractionData, PyStacLoadData, Transform
+from apps.etl.tests.common.base_settings_test import TEST_CACHES
 from apps.etl.utils import remove_ignored_keys
 
 # Set base_collection_url
@@ -30,10 +31,7 @@ TEST_CASES = [
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("case", TEST_CASES)
-@override_settings(
-    TRANSFORM_SUCCESS_RATE=20,
-    CELERY_TASK_ALWAYS_EAGER=True,
-)
+@override_settings(TRANSFORM_SUCCESS_RATE=20, CELERY_TASK_ALWAYS_EAGER=True, CACHES=TEST_CACHES)
 def test_handle_extraction_various_pdc_files(case):
     dataset_dir = settings.BASE_DIR / "apps/etl/tests/dataset/pdc"
 

--- a/apps/etl/tests/sources/usgs_test.py
+++ b/apps/etl/tests/sources/usgs_test.py
@@ -10,6 +10,7 @@ from pystac_monty.sources.common import MontyDataTransformer
 
 from apps.etl.etl_tasks.usgs import ext_and_transform_usgs_latest_data
 from apps.etl.models import ExtractionData, PyStacLoadData, Transform
+from apps.etl.tests.common.base_settings_test import TEST_CACHES
 from apps.etl.utils import remove_ignored_keys
 
 # Set base_collection_url
@@ -30,9 +31,7 @@ TEST_CASES = [
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("case", TEST_CASES)
-@override_settings(
-    CELERY_TASK_ALWAYS_EAGER=True,
-)
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True, CACHES=TEST_CACHES)
 def test_handle_extraction_various_usgs_files(case):
     dataset_dir = settings.BASE_DIR / "apps/etl/tests/dataset/usgs"
 

--- a/apps/etl/transform/sources/desinventar.py
+++ b/apps/etl/transform/sources/desinventar.py
@@ -11,7 +11,7 @@ from pystac_monty.sources.desinventar import (
 
 from apps.etl.models import ExtractionData, Transform, get_trace_id
 from apps.etl.transform.sources.handler import BaseTransformerHandler
-from main.celery import app
+from main.celery import CeleryQueue, app
 from main.configs import etl_config
 from main.logging import log_extra
 
@@ -83,6 +83,6 @@ class DesinventarTransformHandler(BaseTransformerHandler[DesinventarTransformer,
             raise e
 
     @staticmethod
-    @app.task
+    @app.task(queue=CeleryQueue.TRANSFORM)
     def task(extraction_id: int):  # type: ignore[reportIncompatibleMethodOverride]
         DesinventarTransformHandler().handle_transformation(extraction_id)

--- a/apps/etl/transform/sources/emdat.py
+++ b/apps/etl/transform/sources/emdat.py
@@ -6,7 +6,7 @@ from pystac_monty.sources.emdat import EMDATDataSource, EMDATTransformer
 from apps.etl.models import ExtractionData
 from apps.etl.transform.sources.handler import BaseTransformerHandler
 from apps.etl.utils import write_into_temp_file
-from main.celery import app
+from main.celery import CeleryQueue, app
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +32,6 @@ class EMDATTransformHandler(BaseTransformerHandler[EMDATTransformer, EMDATDataSo
         return result, tmp_files
 
     @staticmethod
-    @app.task
+    @app.task(queue=CeleryQueue.TRANSFORM)
     def task(extraction_id):
         EMDATTransformHandler().handle_transformation(extraction_id)

--- a/apps/etl/transform/sources/gdacs.py
+++ b/apps/etl/transform/sources/gdacs.py
@@ -9,7 +9,7 @@ from pystac_monty.sources.gdacs import (
 
 from apps.etl.transform.sources.handler import BaseTransformerHandler
 from apps.etl.utils import write_into_temp_file
-from main.celery import app
+from main.celery import CeleryQueue, app
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +67,6 @@ class GDACSTransformHandler(BaseTransformerHandler[GDACSTransformer, GDACSDataSo
         return result, tmp_files
 
     @staticmethod
-    @app.task(rate_limit="50/m")
+    @app.task(rate_limit="50/m", queue=CeleryQueue.TRANSFORM)
     def task(extraction_id):
         GDACSTransformHandler().handle_transformation(extraction_id)

--- a/apps/etl/transform/sources/gfd.py
+++ b/apps/etl/transform/sources/gfd.py
@@ -26,6 +26,6 @@ class GFDTransformHandler(BaseTransformerHandler[GFDTransformer, GFDDataSource])
         return result, tmp_files
 
     @staticmethod
-    @app.task(queue=CeleryQueue.DEFAULT)
+    @app.task(queue=CeleryQueue.TRANSFORM)
     def task(extraction_id):
         GFDTransformHandler().handle_transformation(extraction_id)

--- a/apps/etl/transform/sources/gidd.py
+++ b/apps/etl/transform/sources/gidd.py
@@ -27,6 +27,6 @@ class GIDDTransformHandler(BaseTransformerHandler[GIDDTransformer, GIDDDataSourc
         return result, tmp_files
 
     @staticmethod
-    @app.task(queue=CeleryQueue.DEFAULT)
+    @app.task(queue=CeleryQueue.TRANSFORM)
     def task(extraction_id):
         GIDDTransformHandler().handle_transformation(extraction_id)

--- a/apps/etl/transform/sources/glide.py
+++ b/apps/etl/transform/sources/glide.py
@@ -6,7 +6,7 @@ from pystac_monty.sources.glide import GlideDataSource, GlideTransformer
 from apps.etl.models import ExtractionData
 from apps.etl.transform.sources.handler import BaseTransformerHandler
 from apps.etl.utils import write_into_temp_file
-from main.celery import app
+from main.celery import CeleryQueue, app
 
 
 class GlideTransformHandler(BaseTransformerHandler[GlideTransformer, GlideDataSource]):
@@ -29,7 +29,7 @@ class GlideTransformHandler(BaseTransformerHandler[GlideTransformer, GlideDataSo
         return result, tmp_files
 
     @staticmethod
-    @app.task
+    @app.task(queue=CeleryQueue.TRANSFORM)
     def task(extraction_id):
         extraction_obj = ExtractionData.objects.get(id=extraction_id)
         with extraction_obj.resp_data.open() as file_data:

--- a/apps/etl/transform/sources/idu.py
+++ b/apps/etl/transform/sources/idu.py
@@ -27,6 +27,6 @@ class IDUTransformHandler(BaseTransformerHandler[IDUTransformer, IDUDataSource])
         return result, tmp_files
 
     @staticmethod
-    @app.task(queue=CeleryQueue.DEFAULT)
+    @app.task(queue=CeleryQueue.TRANSFORM)
     def task(extraction_id):
         IDUTransformHandler().handle_transformation(extraction_id)

--- a/apps/etl/transform/sources/noaa_ibtracs.py
+++ b/apps/etl/transform/sources/noaa_ibtracs.py
@@ -5,7 +5,7 @@ from pystac_monty.sources.ibtracs import IBTrACSDataSource, IBTrACSTransformer
 
 from apps.etl.transform.sources.handler import BaseTransformerHandler
 from apps.etl.utils import write_into_temp_file
-from main.celery import app
+from main.celery import CeleryQueue, app
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +31,6 @@ class IbtracsTransformHandler(BaseTransformerHandler[IBTrACSTransformer, IBTrACS
         return result, tmp_files
 
     @staticmethod
-    @app.task
+    @app.task(queue=CeleryQueue.TRANSFORM)
     def task(extraction_id):
         IbtracsTransformHandler().handle_transformation(extraction_id)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ x-server: &base_server_setup
       DB_PORT: ${DB_PORT:-5432}
       CELERY_BROKER_URL: ${CELERY_BROKER_URL:-amqp://monty:monty@rabbitmq:5672/celery}
       CELERY_RESULT_BACKEND: ${CELERY_RESULT_BACKEND:-redis://redis:6379/0}
+      CACHE_REDIS_URL: ${CACHE_REDIS_URL:-redis://redis:6379/2}
       # Health-checks
       HEALTHCHECK_REDIS_URL: ${CELERY_RESULT_BACKEND:-redis://redis:6379/1}
       HEALTHCHECK_RABBITMQ_URL: ${CELERY_BROKER_URL:-amqp://monty:monty@rabbitmq:5672/celery}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ x-server: &base_server_setup
       CELERY_BROKER_URL: ${CELERY_BROKER_URL:-amqp://monty:monty@rabbitmq:5672/celery}
       CELERY_RESULT_BACKEND: ${CELERY_RESULT_BACKEND:-redis://redis:6379/0}
       CACHE_REDIS_URL: ${CACHE_REDIS_URL:-redis://redis:6379/2}
+      TEST_CACHE_REDIS_URL: ${TEST_CACHE_REDIS_URL:-redis://redis:6379/11}
       # Health-checks
       HEALTHCHECK_REDIS_URL: ${CELERY_RESULT_BACKEND:-redis://redis:6379/1}
       HEALTHCHECK_RABBITMQ_URL: ${CELERY_BROKER_URL:-amqp://monty:monty@rabbitmq:5672/celery}

--- a/helm/templates/config/secret.yaml
+++ b/helm/templates/config/secret.yaml
@@ -53,6 +53,7 @@ stringData:
   {{- if .Values.redis.enabled }}
   CELERY_RESULT_BACKEND: "redis://{{ printf "%s-master" (include "common.names.fullname" .Subcharts.redis) }}:6379/0"
   HEALTHCHECK_REDIS_URL: "redis://{{ printf "%s-master" (include "common.names.fullname" .Subcharts.redis) }}:6379/1"
+  CACHE_REDIS_URL: "redis://{{ printf "%s-master" (include "common.names.fullname" .Subcharts.redis) }}:6379/2"
   {{- else }}
   CELERY_RESULT_BACKEND: {{ required "secrets.CELERY_RESULT_BACKEND" .Values.env.CELERY_RESULT_BACKEND | quote }}
   HEALTHCHECK_REDIS_URL: {{ required "secrets.HEALTHCHECK_REDIS_URL" .Values.env.HEALTHCHECK_REDIS_URL | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -156,25 +156,21 @@ worker:
     # NOTE: Make sure keys are lowercase
     default:
       enabled: true
-      replicaCount: 5
+      replicaCount: 1
       celeryArgs: ["--concurrency", "5", "--max-tasks-per-child", "5", "-Q", "default", "--prefetch-multiplier", "2"]
     extraction:
       enabled: true
-      replicaCount: 2
+      replicaCount: 5
       celeryArgs: ["--concurrency", "3", "--max-tasks-per-child", "5", "-Q", "extraction", "--prefetch-multiplier", "2"]
     transform:
       enabled: true
-      replicaCount: 2
+      replicaCount: 3
       celeryArgs: ["--concurrency", "5", "--max-tasks-per-child", "5", "-Q", "transform", "--prefetch-multiplier", "2"]
     # By source
     usgs-extraction:
       enabled: true
       replicaCount: 1
       celeryArgs: ["--concurrency", "5", "--max-tasks-per-child", "5", "-Q", "usgs-extraction", "--prefetch-multiplier", "2"]
-    load-to-stac:
-      enabled: true
-      replicaCount: 1
-      celeryArgs: ["--concurrency", "5", "--max-tasks-per-child", "5", "-Q", "load-to-stac", "--prefetch-multiplier", "2"]
 
 argoHooks:
   # NOTE: Make sure keys are lowercase

--- a/main/cache.py
+++ b/main/cache.py
@@ -15,7 +15,7 @@ class CeleryLock:
     @staticmethod
     @contextmanager
     def redis_lock(lock_id: str, *, lock_expire: int | None = None):
-        lock_expire_ = lock_expire or settings.REDIS_LOCK_EXPIRE
+        lock_expire_ = lock_expire or settings.DEFAULT_REDIS_LOCK_EXPIRE
         timeout_at: float = time.monotonic() + lock_expire_ - 3
         # cache.add fails if the key already exists
         status = cache.add(lock_id, 1, lock_expire_)

--- a/main/cache.py
+++ b/main/cache.py
@@ -1,0 +1,32 @@
+import time
+from contextlib import contextmanager
+
+from django.conf import settings
+from django.core.cache import caches
+from django_redis.client import DefaultClient  # type: ignore[reportMissingTypeStubs]
+
+cache: DefaultClient = caches["default"]  # type: ignore[reportAssignmentType]
+
+
+class CeleryLock:
+    class Key:
+        LOAD_TO_STAC = "LOAD_TO_STAC"
+
+    @staticmethod
+    @contextmanager
+    def redis_lock(lock_id: str, *, lock_expire: int | None = None):
+        lock_expire_ = lock_expire or settings.REDIS_LOCK_EXPIRE
+        timeout_at: float = time.monotonic() + lock_expire_ - 3
+        # cache.add fails if the key already exists
+        status = cache.add(lock_id, 1, lock_expire_)
+        try:
+            yield status
+        finally:
+            # memcache delete is very slow, but we have to use it to take
+            # advantage of using add() for atomic locking
+            if time.monotonic() < timeout_at and status:
+                # don't release the lock if we exceeded the timeout
+                # to lessen the chance of releasing an expired lock
+                # owned by someone else
+                # also don't release the lock if we didn't acquire it
+                cache.delete(lock_id)

--- a/main/celery.py
+++ b/main/celery.py
@@ -30,8 +30,6 @@ class CeleryQueue:
 
     # Specific
     USGS_EXTRACTION = "usgs-extraction"
-    # Load to STAC
-    LOAD_TO_STAC = "load-to-stac"
 
 
 app.conf.task_default_queue = CeleryQueue.DEFAULT

--- a/main/cronjobs.py
+++ b/main/cronjobs.py
@@ -171,7 +171,7 @@ SCHEDULES: dict[str, CronJob] = {
             checkin_margin=5,
             max_runtime=60,
         ),
-        options=CronJobOption(expires=TimeConstants.SECONDS_IN_A_HOUR, queue="load-to-stac"),
+        options=CronJobOption(expires=TimeConstants.SECONDS_IN_A_HOUR),
     ),
     **{
         f"celery_queue_uptime_{celery_queue_name}": CronJob(

--- a/main/cronjobs.py
+++ b/main/cronjobs.py
@@ -46,8 +46,9 @@ class TimeConstants:
     SECONDS_IN_A_HOUR = 60 * 60
     SECONDS_IN_A_WEEK = 7 * 24 * 60 * 60
     SECONDS_IN_A_MINUTE = 60
-    SECONDS_IN_A_DAY = 60 * 60 * 24
-    SECONDS_IN_HALF_DAY = 60 * 60 * 12
+    SECONDS_IN_A_DAY = 24 * 60 * 60
+    SECONDS_IN_HALF_DAY = 12 * 60 * 60
+    SECONDS_IN_SIX_HOURS = 6 * 60 * 60
 
 
 class CronJob(typing.NamedTuple):

--- a/main/settings.py
+++ b/main/settings.py
@@ -51,6 +51,7 @@ env = environ.Env(
     CELERY_RESULT_BACKEND=str,
     # Cache
     CACHE_REDIS_URL=str,
+    TEST_CACHE_REDIS_URL=(str, None),
     # Storage
     # -- Static, Media configs
     DJANGO_STATIC_URL=(str, "/static/"),
@@ -172,9 +173,10 @@ CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 
 # Redis lock
-REDIS_LOCK_EXPIRE = 6 * 60 * 60  # Lock expires in 6 hrs (in mins)
+DEFAULT_REDIS_LOCK_EXPIRE = 6 * 60 * 60  # Lock expires in 6 hrs (in mins)
 
 CACHE_REDIS_URL = env("CACHE_REDIS_URL")
+TEST_CACHE_REDIS_URL = env("TEST_CACHE_REDIS_URL")
 
 CACHES = {
     "default": {
@@ -183,9 +185,10 @@ CACHES = {
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         },
-        "local-memory": {
-            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-        },
+        "KEY_PREFIX": "djc-",
+    },
+    "local-memory": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
     },
 }
 

--- a/main/settings.py
+++ b/main/settings.py
@@ -173,7 +173,7 @@ CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 
 # Redis lock
-DEFAULT_REDIS_LOCK_EXPIRE = 6 * 60 * 60  # Lock expires in 6 hrs (in mins)
+DEFAULT_REDIS_LOCK_EXPIRE = 30 * 60  # Lock expires in 30 mins
 
 CACHE_REDIS_URL = env("CACHE_REDIS_URL")
 TEST_CACHE_REDIS_URL = env("TEST_CACHE_REDIS_URL")

--- a/main/settings.py
+++ b/main/settings.py
@@ -49,6 +49,8 @@ env = environ.Env(
     # Celery
     CELERY_BROKER_URL=str,
     CELERY_RESULT_BACKEND=str,
+    # Cache
+    CACHE_REDIS_URL=str,
     # Storage
     # -- Static, Media configs
     DJANGO_STATIC_URL=(str, "/static/"),
@@ -171,6 +173,21 @@ CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 
 # Redis lock
 REDIS_LOCK_EXPIRE = 60 * 60  # Lock expires in 1 hr
+
+CACHE_REDIS_URL = env("CACHE_REDIS_URL")
+
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": CACHE_REDIS_URL,
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        },
+        "local-memory": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        },
+    },
+}
 
 # Application definition
 

--- a/main/settings.py
+++ b/main/settings.py
@@ -172,7 +172,7 @@ CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 
 # Redis lock
-REDIS_LOCK_EXPIRE = 60 * 60  # Lock expires in 1 hr
+REDIS_LOCK_EXPIRE = 6 * 60 * 60  # Lock expires in 6 hrs (in mins)
 
 CACHE_REDIS_URL = env("CACHE_REDIS_URL")
 

--- a/main/settings.py
+++ b/main/settings.py
@@ -169,6 +169,9 @@ CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 
+# Redis lock
+REDIS_LOCK_EXPIRE = 60 * 60  # Lock expires in 1 hr
+
 # Application definition
 
 INSTALLED_APPS = [


### PR DESCRIPTION
## Changes

* Add the celery lock while loading STAC items to the STAC server

## This PR doesn't introduce any:

- [X] temporary files, auto-generated files or secret keys
- [X] n+1 queries
- [X] linter issues
- [X] `print`
- [X] typos
- [X] unwanted comments

## This PR contains valid:

- [ ] tests
