### PR TITLE
Bump the rabbitmq storage to 4Gi

### DIFF
--- a/helm/snapshots/prod.yaml
+++ b/helm/snapshots/prod.yaml
@@ -980,7 +980,7 @@ metadata:
 spec:
   image: rabbitmq:4.2.6-management
   persistence:
-    storage: 3Gi
+    storage: 4Gi
   rabbitmq:
     additionalConfig: |
       default_vhost = celery

--- a/helm/snapshots/staging.yaml
+++ b/helm/snapshots/staging.yaml
@@ -980,7 +980,7 @@ metadata:
 spec:
   image: rabbitmq:4.2.6-management
   persistence:
-    storage: 3Gi
+    storage: 4Gi
   rabbitmq:
     additionalConfig: |
       default_vhost = celery

--- a/helm/values/operators.yaml
+++ b/helm/values/operators.yaml
@@ -68,4 +68,4 @@ app:
             consumer_timeout = 7200000
         persistence:
          # storageClassName:
-         storage: "3Gi"
+         storage: "4Gi"


### PR DESCRIPTION
## Changes

* Bump the rabbitmq storage to 4Gi

## This PR doesn't introduce any:

- [X] temporary files, auto-generated files or secret keys
- [X] n+1 queries
- [X] linter issues
- [X] `print`
- [X] typos
- [X] unwanted comments

## This PR contains valid:

- [ ] tests
