### PR TITLE
chore(keda): remove replicas from values.

### DIFF
--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: banjo-helm
   repository: oci://ghcr.io/toggle-corp
-  version: 0.2.6
+  version: 0.2.8
 - name: geocoding-helm
   repository: oci://ghcr.io/ifrcgo/geocoding-service
   version: 0.0.1-feature-geocoding-lite.b9897dd
-digest: sha256:d82beff63fa29fc87bc0976008a6a2f14cd8d220392fe17f01880450e31029df
-generated: "2026-04-09T11:49:33.640139161+05:45"
+digest: sha256:4582f583bbe47297d0f858a67146785837a6decbffe4ef77779ca1b146dcf37f
+generated: "2026-04-16T10:07:09.970396734+05:45"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -9,7 +9,7 @@ sources:
 dependencies:
   - name: banjo-helm
     alias: app
-    version: 0.2.6
+    version: 0.2.8
     repository: oci://ghcr.io/toggle-corp
   - name: geocoding-helm
     alias: geocoding

--- a/helm/snapshots/alpha-1.yaml
+++ b/helm/snapshots/alpha-1.yaml
@@ -1201,7 +1201,6 @@ metadata:
     environment: ALPHA-1
     release: release-name
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: monty-etl-1
@@ -1270,7 +1269,6 @@ metadata:
     environment: ALPHA-1
     release: release-name
 spec:
-  replicas: 2
   selector:
     matchLabels:
       app: monty-etl-1
@@ -1339,7 +1337,6 @@ metadata:
     environment: ALPHA-1
     release: release-name
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: monty-etl-1
@@ -2405,14 +2402,14 @@ spec:
     name: monty-etl-1-worker-default
   minReplicaCount: 1
   maxReplicaCount: 8
+  pollingInterval: 5
+  cooldownPeriod: 30
   triggers:
     - type: rabbitmq
       metadata:
         queueName: default
         mode: QueueLength
         value: "500"
-        pollingInterval: "5"
-        cooldownPeriod: "30"
       authenticationRef:
         name: keda-trigger-auth-rabbitmq-conn
 ---
@@ -2427,14 +2424,14 @@ spec:
     name: monty-etl-1-worker-extraction
   minReplicaCount: 1
   maxReplicaCount: 8
+  pollingInterval: 5
+  cooldownPeriod: 30
   triggers:
     - type: rabbitmq
       metadata:
         queueName: extraction
         mode: QueueLength
         value: "500"
-        pollingInterval: "5"
-        cooldownPeriod: "30"
       authenticationRef:
         name: keda-trigger-auth-rabbitmq-conn
 ---
@@ -2449,14 +2446,14 @@ spec:
     name: monty-etl-1-worker-transform
   minReplicaCount: 1
   maxReplicaCount: 8
+  pollingInterval: 5
+  cooldownPeriod: 30
   triggers:
     - type: rabbitmq
       metadata:
         queueName: transform
         mode: QueueLength
         value: "500"
-        pollingInterval: "5"
-        cooldownPeriod: "30"
       authenticationRef:
         name: keda-trigger-auth-rabbitmq-conn
 ---
@@ -2469,8 +2466,8 @@ metadata:
 spec:
   secretTargetRef:
     - parameter: host
-      name: monty-rabbitmq-default-user
-      key: connection_string
+      name: monty-etl-1-secret
+      key: CELERY_RABBITMQ_CONNECTION_STRING
     - parameter: vhostName
       name: monty-etl-1-secret
       key: CELERY_RABBITMQ_VHOST
@@ -2513,7 +2510,7 @@ spec:
       serviceAccountName: montandon-etl-minio
       initContainers:
         - name: wait-for-available-minio
-          image: docker.io/bitnami/os-shell:12-debian-12-r35
+          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r35
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/helm/snapshots/prod.yaml
+++ b/helm/snapshots/prod.yaml
@@ -48,7 +48,7 @@ metadata:
 spec:
   accessModes:
     - "ReadWriteOnce"
-  storageClassName: default
+  storageClassName: local-path
   resources:
     requests:
       storage: 3Gi
@@ -368,7 +368,6 @@ metadata:
     environment: PROD
     release: release-name
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: monty-etl
@@ -554,7 +553,6 @@ metadata:
     environment: PROD
     release: release-name
 spec:
-  replicas: 2
   selector:
     matchLabels:
       app: monty-etl
@@ -647,7 +645,6 @@ metadata:
     environment: PROD
     release: release-name
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: monty-etl
@@ -1004,14 +1001,14 @@ spec:
     name: monty-etl-worker-default
   minReplicaCount: 1
   maxReplicaCount: 8
+  pollingInterval: 5
+  cooldownPeriod: 30
   triggers:
     - type: rabbitmq
       metadata:
         queueName: default
         mode: QueueLength
         value: "500"
-        pollingInterval: "5"
-        cooldownPeriod: "30"
       authenticationRef:
         name: keda-trigger-auth-rabbitmq-conn
 ---
@@ -1026,14 +1023,14 @@ spec:
     name: monty-etl-worker-extraction
   minReplicaCount: 1
   maxReplicaCount: 8
+  pollingInterval: 5
+  cooldownPeriod: 30
   triggers:
     - type: rabbitmq
       metadata:
         queueName: extraction
         mode: QueueLength
         value: "500"
-        pollingInterval: "5"
-        cooldownPeriod: "30"
       authenticationRef:
         name: keda-trigger-auth-rabbitmq-conn
 ---
@@ -1048,14 +1045,14 @@ spec:
     name: monty-etl-worker-transform
   minReplicaCount: 1
   maxReplicaCount: 8
+  pollingInterval: 5
+  cooldownPeriod: 30
   triggers:
     - type: rabbitmq
       metadata:
         queueName: transform
         mode: QueueLength
         value: "500"
-        pollingInterval: "5"
-        cooldownPeriod: "30"
       authenticationRef:
         name: keda-trigger-auth-rabbitmq-conn
 ---
@@ -1157,8 +1154,8 @@ metadata:
 spec:
   secretTargetRef:
     - parameter: host
-      name: monty-rabbitmq-default-user
-      key: connection_string
+      name: monty-etl-secret
+      key: CELERY_RABBITMQ_CONNECTION_STRING
     - parameter: vhostName
       name: monty-etl-secret
       key: CELERY_RABBITMQ_VHOST

--- a/helm/snapshots/staging.yaml
+++ b/helm/snapshots/staging.yaml
@@ -48,7 +48,7 @@ metadata:
 spec:
   accessModes:
     - "ReadWriteOnce"
-  storageClassName: default
+  storageClassName: local-path
   resources:
     requests:
       storage: 3Gi
@@ -368,7 +368,6 @@ metadata:
     environment: STAGING
     release: release-name
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: monty-etl
@@ -554,7 +553,6 @@ metadata:
     environment: STAGING
     release: release-name
 spec:
-  replicas: 2
   selector:
     matchLabels:
       app: monty-etl
@@ -647,7 +645,6 @@ metadata:
     environment: STAGING
     release: release-name
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: monty-etl
@@ -1004,14 +1001,14 @@ spec:
     name: monty-etl-worker-default
   minReplicaCount: 1
   maxReplicaCount: 8
+  pollingInterval: 5
+  cooldownPeriod: 30
   triggers:
     - type: rabbitmq
       metadata:
         queueName: default
         mode: QueueLength
         value: "500"
-        pollingInterval: "5"
-        cooldownPeriod: "30"
       authenticationRef:
         name: keda-trigger-auth-rabbitmq-conn
 ---
@@ -1026,14 +1023,14 @@ spec:
     name: monty-etl-worker-extraction
   minReplicaCount: 1
   maxReplicaCount: 8
+  pollingInterval: 5
+  cooldownPeriod: 30
   triggers:
     - type: rabbitmq
       metadata:
         queueName: extraction
         mode: QueueLength
         value: "500"
-        pollingInterval: "5"
-        cooldownPeriod: "30"
       authenticationRef:
         name: keda-trigger-auth-rabbitmq-conn
 ---
@@ -1048,14 +1045,14 @@ spec:
     name: monty-etl-worker-transform
   minReplicaCount: 1
   maxReplicaCount: 8
+  pollingInterval: 5
+  cooldownPeriod: 30
   triggers:
     - type: rabbitmq
       metadata:
         queueName: transform
         mode: QueueLength
         value: "500"
-        pollingInterval: "5"
-        cooldownPeriod: "30"
       authenticationRef:
         name: keda-trigger-auth-rabbitmq-conn
 ---
@@ -1157,8 +1154,8 @@ metadata:
 spec:
   secretTargetRef:
     - parameter: host
-      name: monty-rabbitmq-default-user
-      key: connection_string
+      name: monty-etl-secret
+      key: CELERY_RABBITMQ_CONNECTION_STRING
     - parameter: vhostName
       name: monty-etl-secret
       key: CELERY_RABBITMQ_VHOST

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -16,7 +16,7 @@ geocoding:
         memory: 3Gi
     persistence:
       enabled: true
-      storageClassName: default
+      storageClassName: "local-path"
       size: 3Gi
 
 app:
@@ -134,21 +134,17 @@ app:
       # NOTE: Make sure keys are lowercase
       default:
         enabled: true
-        replicaCount: 1
         celeryArgs: ["-Q", "default", "--concurrency", "5", "--max-tasks-per-child", "25"]
       extraction:
         enabled: true
-        replicaCount: 1
         celeryArgs: ["-Q", "extraction", "--concurrency", "2", "--max-tasks-per-child", "25"]
       transform:
         enabled: true
-        replicaCount: 2
         celeryArgs: ["-Q", "transform", "--concurrency", "2", "--max-tasks-per-child", "25"]
       # By source
       # TODO: Is this used?
       usgs-extraction:
-        enabled: true
-        replicaCount: 1
+        enabled: false
         celeryArgs: ["-Q", "usgs-extraction", "--concurrency", "2", "--max-tasks-per-child", "25"]
 
   argoHook:
@@ -211,8 +207,8 @@ app:
       spec:
         secretTargetRef:
           - parameter: host
-            name: monty-rabbitmq-default-user
-            key: connection_string
+            name: {{ include "django-app.secretname" . }}
+            key: CELERY_RABBITMQ_CONNECTION_STRING
           - parameter: vhostName
             name: {{ include "django-app.secretname" . }}
             key: CELERY_RABBITMQ_VHOST
@@ -227,14 +223,14 @@ app:
           name: {{ include "django-app.fullname" $ }}-worker-default
         minReplicaCount: 1
         maxReplicaCount: 8
+        pollingInterval: 5
+        cooldownPeriod: 30
         triggers:
           - type: rabbitmq
             metadata:
               queueName: default
               mode: QueueLength
               value: "500"
-              pollingInterval: "5"
-              cooldownPeriod: "30"
             authenticationRef:
               name: keda-trigger-auth-rabbitmq-conn
 
@@ -248,14 +244,14 @@ app:
           name: {{ include "django-app.fullname" $ }}-worker-extraction
         minReplicaCount: 1
         maxReplicaCount: 8
+        pollingInterval: 5
+        cooldownPeriod: 30
         triggers:
           - type: rabbitmq
             metadata:
               queueName: extraction
               mode: QueueLength
               value: "500"
-              pollingInterval: "5"
-              cooldownPeriod: "30"
             authenticationRef:
               name: keda-trigger-auth-rabbitmq-conn
 
@@ -269,13 +265,13 @@ app:
           name: {{ include "django-app.fullname" $ }}-worker-transform
         minReplicaCount: 1
         maxReplicaCount: 8
+        pollingInterval: 5
+        cooldownPeriod: 30
         triggers:
           - type: rabbitmq
             metadata:
               queueName: transform
               mode: QueueLength
               value: "500"
-              pollingInterval: "5"
-              cooldownPeriod: "30"
             authenticationRef:
               name: keda-trigger-auth-rabbitmq-conn


### PR DESCRIPTION
## Changes

- Update snapshot to latest values.
- Minio volume provisioning.
- Change the storageclass of geocoding to local path

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [X] n+1 queries
- [X] linter issues
- [X] `print`
- [X] typos
- [X] unwanted comments

## This PR contains valid:

- [X] tests
