### PR TITLE
fix: use a different eoapi global url to be consumed within stac items

### DIFF
--- a/apps/etl/load/sources/base.py
+++ b/apps/etl/load/sources/base.py
@@ -19,9 +19,9 @@ def load_collections(*, skip_collection_create: bool, timeout: int = 30) -> list
     """
     logger.info("Sync collections")
 
-    assert etl_config.EOAPI_STAC_API is not None
+    assert etl_config.EOAPI_STAC_API_INTERNAL is not None
 
-    url = f"{etl_config.EOAPI_STAC_API}/collections"
+    url = f"{etl_config.EOAPI_STAC_API_INTERNAL}/collections"
     # response = requests.get(f"{url}?limit={len(ITEM_TYPE_COLLECTION_ID_MAP.keys())}", headers=HEADERS)
     # NOTE : We have assigned the limit to be 50 but in actual, we need to
     # get the length from the ITEM_TYPE_COLLEcTION_ID_MAP.keys() but the issue is
@@ -73,9 +73,9 @@ def load_collections(*, skip_collection_create: bool, timeout: int = 30) -> list
 def send_post_request_to_stac_api(
     *, bulk_mgr: BulkUpdateManager, py_stac_obj: PyStacLoadData, to_update: bool = False, timeout: int = 30
 ):
-    assert etl_config.EOAPI_STAC_API is not None
+    assert etl_config.EOAPI_STAC_API_INTERNAL is not None
 
-    url = f"{etl_config.EOAPI_STAC_API}/collections/{py_stac_obj.collection_id}/items"
+    url = f"{etl_config.EOAPI_STAC_API_INTERNAL}/collections/{py_stac_obj.collection_id}/items"
 
     if to_update:
         # Note: not to use slash(/) at the end to avoid redirection
@@ -126,8 +126,8 @@ def load_data(
     """Load data into STAC"""
     logger.info("Loading data start")
 
-    if etl_config.EOAPI_STAC_API is None:
-        logger.warning(f"EOAPI_STAC_API is not defined. {etl_config.EOAPI_STAC_API}.. Skipping...")
+    if etl_config.EOAPI_STAC_API_INTERNAL is None:
+        logger.warning(f"EOAPI_STAC_API_INTERNAL is not defined. {etl_config.EOAPI_STAC_API_INTERNAL}.. Skipping...")
         return
 
     available_collections_id = load_collections(

--- a/apps/etl/management/commands/create_collections.py
+++ b/apps/etl/management/commands/create_collections.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
         eoapi_url: str | None = options.get("eoapi_url")
         eoapi_token: str | None = options.get("token")
         if not eoapi_url:
-            eoapi_url = settings.EOAPI_STAC_API
+            eoapi_url = settings.EOAPI_STAC_API_INTERNAL
             if not eoapi_url:
                 self.stderr.write(self.style.ERROR("eoAPI url not found in the environment. Exiting."))
                 return

--- a/apps/etl/transform/sources/desinventar.py
+++ b/apps/etl/transform/sources/desinventar.py
@@ -44,7 +44,7 @@ class DesinventarTransformHandler(BaseTransformerHandler[DesinventarTransformer,
             iso3=iso3,
             country_code=country_code,
         )
-        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL)
+        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API_PUBLIC)
 
         return result
 

--- a/apps/etl/transform/sources/desinventar.py
+++ b/apps/etl/transform/sources/desinventar.py
@@ -44,7 +44,7 @@ class DesinventarTransformHandler(BaseTransformerHandler[DesinventarTransformer,
             iso3=iso3,
             country_code=country_code,
         )
-        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API)
+        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL)
 
         return result
 

--- a/apps/etl/transform/sources/emdat.py
+++ b/apps/etl/transform/sources/emdat.py
@@ -34,7 +34,7 @@ class EMDATTransformHandler(BaseTransformerHandler[EMDATTransformer, EMDATDataSo
                 source_url=extraction_obj.url,
                 input_data=File(path=data_file.name, data_type=DataType.FILE),
             ),
-            eoapi_url=etl_config.EOAPI_STAC_API,
+            eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL,
         )
 
         return result

--- a/apps/etl/transform/sources/emdat.py
+++ b/apps/etl/transform/sources/emdat.py
@@ -34,7 +34,7 @@ class EMDATTransformHandler(BaseTransformerHandler[EMDATTransformer, EMDATDataSo
                 source_url=extraction_obj.url,
                 input_data=File(path=data_file.name, data_type=DataType.FILE),
             ),
-            eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL,
+            eoapi_url=etl_config.EOAPI_STAC_API_PUBLIC,
         )
 
         return result

--- a/apps/etl/transform/sources/gdacs.py
+++ b/apps/etl/transform/sources/gdacs.py
@@ -96,7 +96,7 @@ class GDACSTransformHandler(BaseTransformerHandler[GDACSTransformer, GDACSDataSo
                 event_data=File(path=data_file.name, data_type=DataType.FILE),
                 episodes=episodes,
             ),
-            eoapi_url=etl_config.EOAPI_STAC_API,
+            eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL,
         )
 
         return result

--- a/apps/etl/transform/sources/gdacs.py
+++ b/apps/etl/transform/sources/gdacs.py
@@ -96,7 +96,7 @@ class GDACSTransformHandler(BaseTransformerHandler[GDACSTransformer, GDACSDataSo
                 event_data=File(path=data_file.name, data_type=DataType.FILE),
                 episodes=episodes,
             ),
-            eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL,
+            eoapi_url=etl_config.EOAPI_STAC_API_PUBLIC,
         )
 
         return result

--- a/apps/etl/transform/sources/gfd.py
+++ b/apps/etl/transform/sources/gfd.py
@@ -30,7 +30,7 @@ class GFDTransformHandler(BaseTransformerHandler[GFDTransformer, GFDDataSource])
         data_source = GenericDataSource(
             source_url=extraction_obj.url, input_data=File(path=data_file.name, data_type=DataType.FILE)
         )
-        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL)
+        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API_PUBLIC)
         return result
 
     @staticmethod

--- a/apps/etl/transform/sources/gfd.py
+++ b/apps/etl/transform/sources/gfd.py
@@ -30,7 +30,7 @@ class GFDTransformHandler(BaseTransformerHandler[GFDTransformer, GFDDataSource])
         data_source = GenericDataSource(
             source_url=extraction_obj.url, input_data=File(path=data_file.name, data_type=DataType.FILE)
         )
-        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API)
+        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL)
         return result
 
     @staticmethod

--- a/apps/etl/transform/sources/gidd.py
+++ b/apps/etl/transform/sources/gidd.py
@@ -30,7 +30,7 @@ class GIDDTransformHandler(BaseTransformerHandler[GIDDTransformer, GIDDDataSourc
             source_url=extraction_obj.url, input_data=File(path=data_file.name, data_type=DataType.FILE)
         )
 
-        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API)
+        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL)
 
         return result
 

--- a/apps/etl/transform/sources/gidd.py
+++ b/apps/etl/transform/sources/gidd.py
@@ -30,7 +30,7 @@ class GIDDTransformHandler(BaseTransformerHandler[GIDDTransformer, GIDDDataSourc
             source_url=extraction_obj.url, input_data=File(path=data_file.name, data_type=DataType.FILE)
         )
 
-        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL)
+        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API_PUBLIC)
 
         return result
 

--- a/apps/etl/transform/sources/glide.py
+++ b/apps/etl/transform/sources/glide.py
@@ -32,7 +32,7 @@ class GlideTransformHandler(BaseTransformerHandler[GlideTransformer, GlideDataSo
                 source_url=extraction_obj.url,
                 input_data=File(path=data_file.name, data_type=DataType.FILE),
             ),
-            eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL,
+            eoapi_url=etl_config.EOAPI_STAC_API_PUBLIC,
         )
         return result
 

--- a/apps/etl/transform/sources/glide.py
+++ b/apps/etl/transform/sources/glide.py
@@ -32,7 +32,7 @@ class GlideTransformHandler(BaseTransformerHandler[GlideTransformer, GlideDataSo
                 source_url=extraction_obj.url,
                 input_data=File(path=data_file.name, data_type=DataType.FILE),
             ),
-            eoapi_url=etl_config.EOAPI_STAC_API,
+            eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL,
         )
         return result
 

--- a/apps/etl/transform/sources/idu.py
+++ b/apps/etl/transform/sources/idu.py
@@ -30,7 +30,7 @@ class IDUTransformHandler(BaseTransformerHandler[IDUTransformer, IDUDataSource])
             source_url=extraction_obj.url, input_data=File(path=data_file.name, data_type=DataType.FILE)
         )
 
-        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL)
+        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API_PUBLIC)
 
         return result
 

--- a/apps/etl/transform/sources/idu.py
+++ b/apps/etl/transform/sources/idu.py
@@ -30,7 +30,7 @@ class IDUTransformHandler(BaseTransformerHandler[IDUTransformer, IDUDataSource])
             source_url=extraction_obj.url, input_data=File(path=data_file.name, data_type=DataType.FILE)
         )
 
-        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API)
+        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL)
 
         return result
 

--- a/apps/etl/transform/sources/ifrc_event.py
+++ b/apps/etl/transform/sources/ifrc_event.py
@@ -33,7 +33,7 @@ class IFRCEventTransformHandler(BaseTransformerHandler[IFRCEventTransformer, IFR
             source_url=extraction_obj.url, input_data=File(path=data_file.name, data_type=DataType.FILE)
         )
 
-        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL)
+        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API_PUBLIC)
 
         return result
 

--- a/apps/etl/transform/sources/ifrc_event.py
+++ b/apps/etl/transform/sources/ifrc_event.py
@@ -33,7 +33,7 @@ class IFRCEventTransformHandler(BaseTransformerHandler[IFRCEventTransformer, IFR
             source_url=extraction_obj.url, input_data=File(path=data_file.name, data_type=DataType.FILE)
         )
 
-        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API)
+        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL)
 
         return result
 

--- a/apps/etl/transform/sources/noaa_ibtracs.py
+++ b/apps/etl/transform/sources/noaa_ibtracs.py
@@ -33,7 +33,7 @@ class IbtracsTransformHandler(BaseTransformerHandler[IBTrACSTransformer, IBTrACS
             input_data=File(path=data_file.name, data_type=DataType.FILE),
         )
 
-        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API)
+        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL)
 
         return result
 

--- a/apps/etl/transform/sources/noaa_ibtracs.py
+++ b/apps/etl/transform/sources/noaa_ibtracs.py
@@ -33,7 +33,7 @@ class IbtracsTransformHandler(BaseTransformerHandler[IBTrACSTransformer, IBTrACS
             input_data=File(path=data_file.name, data_type=DataType.FILE),
         )
 
-        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL)
+        result = cls.transformer_schema(data=data_source, eoapi_url=etl_config.EOAPI_STAC_API_PUBLIC)
 
         return result
 

--- a/apps/etl/transform/sources/pdc.py
+++ b/apps/etl/transform/sources/pdc.py
@@ -59,7 +59,7 @@ class PDCTransformHandler(BaseTransformerHandler[PDCTransformer, PDCDataSource])
                 exposure_detail_data=File(path=tmp_exposure_detail_file.name, data_type=DataType.FILE),
                 geojson_path=geo_json_obj.resp_data.url,
             ),
-            eoapi_url=etl_config.EOAPI_STAC_API,
+            eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL,
         )
 
         return result

--- a/apps/etl/transform/sources/pdc.py
+++ b/apps/etl/transform/sources/pdc.py
@@ -59,7 +59,7 @@ class PDCTransformHandler(BaseTransformerHandler[PDCTransformer, PDCDataSource])
                 exposure_detail_data=File(path=tmp_exposure_detail_file.name, data_type=DataType.FILE),
                 geojson_path=geo_json_obj.resp_data.url,
             ),
-            eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL,
+            eoapi_url=etl_config.EOAPI_STAC_API_PUBLIC,
         )
 
         return result

--- a/apps/etl/transform/sources/usgs.py
+++ b/apps/etl/transform/sources/usgs.py
@@ -61,7 +61,7 @@ class USGSTransformHandler(BaseTransformerHandler[USGSTransformer, USGSDataSourc
                 loss_data=File(path=losses_data_path.name, data_type=DataType.FILE),
                 alerts_data=File(path=alerts_data_path.name, data_type=DataType.FILE),
             ),
-            eoapi_url=etl_config.EOAPI_STAC_API,
+            eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL,
         )
 
         return result

--- a/apps/etl/transform/sources/usgs.py
+++ b/apps/etl/transform/sources/usgs.py
@@ -61,7 +61,7 @@ class USGSTransformHandler(BaseTransformerHandler[USGSTransformer, USGSDataSourc
                 loss_data=File(path=losses_data_path.name, data_type=DataType.FILE),
                 alerts_data=File(path=alerts_data_path.name, data_type=DataType.FILE),
             ),
-            eoapi_url=etl_config.EOAPI_STAC_API_GLOBAL,
+            eoapi_url=etl_config.EOAPI_STAC_API_PUBLIC,
         )
 
         return result

--- a/helm/linter_values.yaml
+++ b/helm/linter_values.yaml
@@ -21,7 +21,8 @@ app:
     # App Domain
     DJANGO_ALLOWED_HOSTS: "*"
     # ETL Load config
-    EOAPI_STAC_API: https://montandon-eoapi.dummy.com/stac
+    EOAPI_STAC_API_INTERNAL: https://montandon-eoapi.dummy.com/stac
+    EOAPI_STAC_API_PUBLIC: https://montandon-eoapi.dummy.com/stac
 
   secrets:
     DJANGO_SECRET_KEY: dummy-secret-key

--- a/helm/snapshots/alpha-1.yaml
+++ b/helm/snapshots/alpha-1.yaml
@@ -526,7 +526,8 @@ data:
   DJANGO_APP_ENVIRONMENT: "ALPHA-1"
   DJANGO_DEBUG: "false"
   DJANGO_TIME_ZONE: "UTC"
-  EOAPI_STAC_API: "https://montandon-eoapi-stage.monty.org/stac"
+  EOAPI_STAC_API_INTERNAL: "https://montandon-eoapi-stage.monty.org/stac"
+  EOAPI_STAC_API_PUBLIC: "https://montandon-eoapi-stage.monty.org/stac"
   EOAPI_SYNC_LIMIT: "5000"
   SENTRY_MONITOR_CELERY_BEAT_TASKS: "true"
   SENTRY_PROFILE_SAMPLE_RATE: "0.2"
@@ -1002,7 +1003,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 7b54fddcd01e3beef28134a942be508b545ccf08ba520e929de473e5cad27470
-        checksum/configmap: d2451572b9f9bc4a9af275f8006d023e33b02846cdadf0147d3cbe301e171dd4
+        checksum/configmap: e4a75c3e25a6e47cb46a7776395d3e73d6f04c0cbc4297b08fd9fcf46fd208ed
       labels:
         app: monty-etl-1
         component: api
@@ -1059,7 +1060,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 7b54fddcd01e3beef28134a942be508b545ccf08ba520e929de473e5cad27470
-        checksum/configmap: d2451572b9f9bc4a9af275f8006d023e33b02846cdadf0147d3cbe301e171dd4
+        checksum/configmap: e4a75c3e25a6e47cb46a7776395d3e73d6f04c0cbc4297b08fd9fcf46fd208ed
       labels:
         app: monty-etl-1
         component: worker-flower
@@ -1116,7 +1117,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 7b54fddcd01e3beef28134a942be508b545ccf08ba520e929de473e5cad27470
-        checksum/configmap: d2451572b9f9bc4a9af275f8006d023e33b02846cdadf0147d3cbe301e171dd4
+        checksum/configmap: e4a75c3e25a6e47cb46a7776395d3e73d6f04c0cbc4297b08fd9fcf46fd208ed
       labels:
         app: monty-etl-1
         component: worker-beat
@@ -1177,7 +1178,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 7b54fddcd01e3beef28134a942be508b545ccf08ba520e929de473e5cad27470
-        checksum/configmap: d2451572b9f9bc4a9af275f8006d023e33b02846cdadf0147d3cbe301e171dd4
+        checksum/configmap: e4a75c3e25a6e47cb46a7776395d3e73d6f04c0cbc4297b08fd9fcf46fd208ed
       labels:
         app: monty-etl-1
         component: worker
@@ -1246,7 +1247,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 7b54fddcd01e3beef28134a942be508b545ccf08ba520e929de473e5cad27470
-        checksum/configmap: d2451572b9f9bc4a9af275f8006d023e33b02846cdadf0147d3cbe301e171dd4
+        checksum/configmap: e4a75c3e25a6e47cb46a7776395d3e73d6f04c0cbc4297b08fd9fcf46fd208ed
       labels:
         app: monty-etl-1
         component: worker
@@ -1315,7 +1316,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 7b54fddcd01e3beef28134a942be508b545ccf08ba520e929de473e5cad27470
-        checksum/configmap: d2451572b9f9bc4a9af275f8006d023e33b02846cdadf0147d3cbe301e171dd4
+        checksum/configmap: e4a75c3e25a6e47cb46a7776395d3e73d6f04c0cbc4297b08fd9fcf46fd208ed
       labels:
         app: monty-etl-1
         component: worker
@@ -1384,7 +1385,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 7b54fddcd01e3beef28134a942be508b545ccf08ba520e929de473e5cad27470
-        checksum/configmap: d2451572b9f9bc4a9af275f8006d023e33b02846cdadf0147d3cbe301e171dd4
+        checksum/configmap: e4a75c3e25a6e47cb46a7776395d3e73d6f04c0cbc4297b08fd9fcf46fd208ed
       labels:
         app: monty-etl-1
         component: worker
@@ -1453,7 +1454,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 7b54fddcd01e3beef28134a942be508b545ccf08ba520e929de473e5cad27470
-        checksum/configmap: d2451572b9f9bc4a9af275f8006d023e33b02846cdadf0147d3cbe301e171dd4
+        checksum/configmap: e4a75c3e25a6e47cb46a7776395d3e73d6f04c0cbc4297b08fd9fcf46fd208ed
       labels:
         app: monty-etl-1
         component: worker
@@ -1524,7 +1525,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 7b54fddcd01e3beef28134a942be508b545ccf08ba520e929de473e5cad27470
-        checksum/configmap: d2451572b9f9bc4a9af275f8006d023e33b02846cdadf0147d3cbe301e171dd4
+        checksum/configmap: e4a75c3e25a6e47cb46a7776395d3e73d6f04c0cbc4297b08fd9fcf46fd208ed
       labels:
         app: monty-etl-1
         component: worker
@@ -1595,7 +1596,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 7b54fddcd01e3beef28134a942be508b545ccf08ba520e929de473e5cad27470
-        checksum/configmap: d2451572b9f9bc4a9af275f8006d023e33b02846cdadf0147d3cbe301e171dd4
+        checksum/configmap: e4a75c3e25a6e47cb46a7776395d3e73d6f04c0cbc4297b08fd9fcf46fd208ed
       labels:
         app: monty-etl-1
         component: worker
@@ -1666,7 +1667,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 7b54fddcd01e3beef28134a942be508b545ccf08ba520e929de473e5cad27470
-        checksum/configmap: d2451572b9f9bc4a9af275f8006d023e33b02846cdadf0147d3cbe301e171dd4
+        checksum/configmap: e4a75c3e25a6e47cb46a7776395d3e73d6f04c0cbc4297b08fd9fcf46fd208ed
       labels:
         app: monty-etl-1
         component: worker
@@ -2232,7 +2233,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 7b54fddcd01e3beef28134a942be508b545ccf08ba520e929de473e5cad27470
-        checksum/configmap: d2451572b9f9bc4a9af275f8006d023e33b02846cdadf0147d3cbe301e171dd4
+        checksum/configmap: e4a75c3e25a6e47cb46a7776395d3e73d6f04c0cbc4297b08fd9fcf46fd208ed
       labels:
         app: monty-etl-1
         component: argo-hooks
@@ -2305,7 +2306,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 7b54fddcd01e3beef28134a942be508b545ccf08ba520e929de473e5cad27470
-        checksum/configmap: d2451572b9f9bc4a9af275f8006d023e33b02846cdadf0147d3cbe301e171dd4
+        checksum/configmap: e4a75c3e25a6e47cb46a7776395d3e73d6f04c0cbc4297b08fd9fcf46fd208ed
       labels:
         app: monty-etl-1
         component: argo-hooks
@@ -2350,7 +2351,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 7b54fddcd01e3beef28134a942be508b545ccf08ba520e929de473e5cad27470
-        checksum/configmap: d2451572b9f9bc4a9af275f8006d023e33b02846cdadf0147d3cbe301e171dd4
+        checksum/configmap: e4a75c3e25a6e47cb46a7776395d3e73d6f04c0cbc4297b08fd9fcf46fd208ed
       labels:
         app: monty-etl-1
         component: argo-hooks

--- a/helm/snapshots/prod.yaml
+++ b/helm/snapshots/prod.yaml
@@ -36,7 +36,8 @@ data:
   DJANGO_APP_ENVIRONMENT: "PROD"
   DJANGO_DEBUG: "false"
   DJANGO_TIME_ZONE: "UTC"
-  EOAPI_STAC_API: "https://montandon-eoapi.ifrc.org/stac"
+  EOAPI_STAC_API_INTERNAL: "https://montandon-eoapi.ifrc.org/stac"
+  EOAPI_STAC_API_PUBLIC: "https://montandon-eoapi.ifrc.org/stac"
 
 ---
 # Source: montandon-etl-helm/charts/geocoding/templates/geocoding/pvc.yaml
@@ -140,7 +141,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/configmap: 8e951f6bc763668344314261f283698baeeccb239a8ae84cb4c037778135dd5d
+        checksum/configmap: f1a93e4b648d446c9c523fa1ffb39c486a539761ba8243fb103b714c4e80db3d
       labels:
         app: monty-etl
         component: api
@@ -221,7 +222,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/configmap: 8e951f6bc763668344314261f283698baeeccb239a8ae84cb4c037778135dd5d
+        checksum/configmap: f1a93e4b648d446c9c523fa1ffb39c486a539761ba8243fb103b714c4e80db3d
       labels:
         app: monty-etl
         component: worker-flower
@@ -302,7 +303,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/configmap: 8e951f6bc763668344314261f283698baeeccb239a8ae84cb4c037778135dd5d
+        checksum/configmap: f1a93e4b648d446c9c523fa1ffb39c486a539761ba8243fb103b714c4e80db3d
       labels:
         app: monty-etl
         component: worker-beat
@@ -387,7 +388,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/configmap: 8e951f6bc763668344314261f283698baeeccb239a8ae84cb4c037778135dd5d
+        checksum/configmap: f1a93e4b648d446c9c523fa1ffb39c486a539761ba8243fb103b714c4e80db3d
       labels:
         app: monty-etl
         component: worker
@@ -480,7 +481,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/configmap: 8e951f6bc763668344314261f283698baeeccb239a8ae84cb4c037778135dd5d
+        checksum/configmap: f1a93e4b648d446c9c523fa1ffb39c486a539761ba8243fb103b714c4e80db3d
       labels:
         app: monty-etl
         component: worker
@@ -573,7 +574,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/configmap: 8e951f6bc763668344314261f283698baeeccb239a8ae84cb4c037778135dd5d
+        checksum/configmap: f1a93e4b648d446c9c523fa1ffb39c486a539761ba8243fb103b714c4e80db3d
       labels:
         app: monty-etl
         component: worker
@@ -666,7 +667,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/configmap: 8e951f6bc763668344314261f283698baeeccb239a8ae84cb4c037778135dd5d
+        checksum/configmap: f1a93e4b648d446c9c523fa1ffb39c486a539761ba8243fb103b714c4e80db3d
       labels:
         app: monty-etl
         component: worker
@@ -802,7 +803,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/configmap: 8e951f6bc763668344314261f283698baeeccb239a8ae84cb4c037778135dd5d
+        checksum/configmap: f1a93e4b648d446c9c523fa1ffb39c486a539761ba8243fb103b714c4e80db3d
       labels:
         app: monty-etl
         component: argo-hooks
@@ -871,7 +872,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/configmap: 8e951f6bc763668344314261f283698baeeccb239a8ae84cb4c037778135dd5d
+        checksum/configmap: f1a93e4b648d446c9c523fa1ffb39c486a539761ba8243fb103b714c4e80db3d
       labels:
         app: monty-etl
         component: argo-hooks

--- a/helm/snapshots/staging.yaml
+++ b/helm/snapshots/staging.yaml
@@ -36,7 +36,8 @@ data:
   DJANGO_APP_ENVIRONMENT: "STAGING"
   DJANGO_DEBUG: "false"
   DJANGO_TIME_ZONE: "UTC"
-  EOAPI_STAC_API: "https://montandon-eoapi-stage.monty.org/stac"
+  EOAPI_STAC_API_INTERNAL: "https://montandon-eoapi-stage.monty.org/stac"
+  EOAPI_STAC_API_PUBLIC: "https://montandon-eoapi-stage.monty.org/stac"
 
 ---
 # Source: montandon-etl-helm/charts/geocoding/templates/geocoding/pvc.yaml
@@ -140,7 +141,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/configmap: 36019ea8ea2546439e46b55371ff9560b75fff628fe36e4601e7be0e84ce66fb
+        checksum/configmap: 9e7e659b73608d6a0f3188b1def3d35a41c5e7159fbad0a1f0bed9835cee5209
       labels:
         app: monty-etl
         component: api
@@ -221,7 +222,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/configmap: 36019ea8ea2546439e46b55371ff9560b75fff628fe36e4601e7be0e84ce66fb
+        checksum/configmap: 9e7e659b73608d6a0f3188b1def3d35a41c5e7159fbad0a1f0bed9835cee5209
       labels:
         app: monty-etl
         component: worker-flower
@@ -302,7 +303,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/configmap: 36019ea8ea2546439e46b55371ff9560b75fff628fe36e4601e7be0e84ce66fb
+        checksum/configmap: 9e7e659b73608d6a0f3188b1def3d35a41c5e7159fbad0a1f0bed9835cee5209
       labels:
         app: monty-etl
         component: worker-beat
@@ -387,7 +388,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/configmap: 36019ea8ea2546439e46b55371ff9560b75fff628fe36e4601e7be0e84ce66fb
+        checksum/configmap: 9e7e659b73608d6a0f3188b1def3d35a41c5e7159fbad0a1f0bed9835cee5209
       labels:
         app: monty-etl
         component: worker
@@ -480,7 +481,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/configmap: 36019ea8ea2546439e46b55371ff9560b75fff628fe36e4601e7be0e84ce66fb
+        checksum/configmap: 9e7e659b73608d6a0f3188b1def3d35a41c5e7159fbad0a1f0bed9835cee5209
       labels:
         app: monty-etl
         component: worker
@@ -573,7 +574,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/configmap: 36019ea8ea2546439e46b55371ff9560b75fff628fe36e4601e7be0e84ce66fb
+        checksum/configmap: 9e7e659b73608d6a0f3188b1def3d35a41c5e7159fbad0a1f0bed9835cee5209
       labels:
         app: monty-etl
         component: worker
@@ -666,7 +667,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/configmap: 36019ea8ea2546439e46b55371ff9560b75fff628fe36e4601e7be0e84ce66fb
+        checksum/configmap: 9e7e659b73608d6a0f3188b1def3d35a41c5e7159fbad0a1f0bed9835cee5209
       labels:
         app: monty-etl
         component: worker
@@ -802,7 +803,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/configmap: 36019ea8ea2546439e46b55371ff9560b75fff628fe36e4601e7be0e84ce66fb
+        checksum/configmap: 9e7e659b73608d6a0f3188b1def3d35a41c5e7159fbad0a1f0bed9835cee5209
       labels:
         app: monty-etl
         component: argo-hooks
@@ -871,7 +872,7 @@ spec:
     metadata:
       annotations:
         checksum/secret: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/configmap: 36019ea8ea2546439e46b55371ff9560b75fff628fe36e4601e7be0e84ce66fb
+        checksum/configmap: 9e7e659b73608d6a0f3188b1def3d35a41c5e7159fbad0a1f0bed9835cee5209
       labels:
         app: monty-etl
         component: argo-hooks

--- a/helm/tests/alpha-1.yaml
+++ b/helm/tests/alpha-1.yaml
@@ -99,7 +99,8 @@ app:
     EOAPI_SYNC_LIMIT: "5000"
     # App Domain
     DJANGO_ALLOWED_HOSTS: "*"
-    EOAPI_STAC_API: https://montandon-eoapi-stage.monty.org/stac
+    EOAPI_STAC_API_INTERNAL: https://montandon-eoapi-stage.monty.org/stac
+    EOAPI_STAC_API_PUBLIC: https://montandon-eoapi-stage.monty.org/stac
 
   secrets:
     DJANGO_SECRET_KEY: "XYZ"

--- a/helm/tests/prod.yaml
+++ b/helm/tests/prod.yaml
@@ -15,7 +15,8 @@ app:
     AZURE_STORAGE_ACCOUNT_NAME: montyXYZ
     AZURE_STORAGE_MANAGED_IDENTITY: "true"
     # ETL Load config
-    EOAPI_STAC_API: "https://montandon-eoapi.ifrc.org/stac"
+    EOAPI_STAC_API_INTERNAL: "https://montandon-eoapi.ifrc.org/stac"
+    EOAPI_STAC_API_PUBLIC: "https://montandon-eoapi.ifrc.org/stac"
 
   serviceAccount:
     annotations:

--- a/helm/tests/staging.yaml
+++ b/helm/tests/staging.yaml
@@ -15,7 +15,8 @@ app:
     AZURE_STORAGE_ACCOUNT_NAME: montystagingXYZ
     AZURE_STORAGE_MANAGED_IDENTITY: "true"
     # ETL Load config
-    EOAPI_STAC_API: "https://montandon-eoapi-stage.monty.org/stac"
+    EOAPI_STAC_API_INTERNAL: "https://montandon-eoapi-stage.monty.org/stac"
+    EOAPI_STAC_API_PUBLIC: "https://montandon-eoapi-stage.monty.org/stac"
 
   serviceAccount:
     annotations:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -182,7 +182,8 @@ app:
     # Azure configs
     AZURE_STORAGE_ENABLE: "false"
     # ETL app config
-    EOAPI_STAC_API: "{{ required \".app.secrets.EOAPI_STAC_API\" nil }}"
+    EOAPI_STAC_API_INTERNAL: "{{ required \".app.secrets.EOAPI_STAC_API_INTERNAL\" nil }}"
+    EOAPI_STAC_API_PUBLIC: "{{ required \".app.secrets.EOAPI_STAC_API_PUBLIC\" nil }}"
 
   secrets:
     DJANGO_SECRET_KEY: "{{ required \".app.secrets.DJANGO_SECRET_KEY\" nil }}"

--- a/helm/values/go-deploy.yaml
+++ b/helm/values/go-deploy.yaml
@@ -25,8 +25,8 @@ app:
     # AZURE_STORAGE_MEDIA_CONTAINER: XXX: go-deploy
     # AZURE_STORAGE_STATIC_CONTAINER: XXX: go-deploy
     # ETL Load config
-    # EOAPI_STAC_API: XXX: go-deploy
-    # EOAPI_STAC_API_GLOBAL: XXX: go-deploy
+    # EOAPI_STAC_API_INTERNAL: XXX: go-deploy
+    # EOAPI_STAC_API_PUBLIC: XXX: go-deploy
 
   serviceAccountName: "service-token-reader"
   serviceAccount:

--- a/helm/values/go-deploy.yaml
+++ b/helm/values/go-deploy.yaml
@@ -26,6 +26,7 @@ app:
     # AZURE_STORAGE_STATIC_CONTAINER: XXX: go-deploy
     # ETL Load config
     # EOAPI_STAC_API: XXX: go-deploy
+    # EOAPI_STAC_API_GLOBAL: XXX: go-deploy
 
   serviceAccountName: "service-token-reader"
   serviceAccount:

--- a/main/configs.py
+++ b/main/configs.py
@@ -179,6 +179,9 @@ class EtlConfig:
 
         self.EOAPI_STAC_API = self.parse_base_url("EOAPI_STAC_API", preserve_path=True, strip_path_trailing_slash=True)
         self.EOAPI_SYNC_LIMIT = self.parse_int_value_required("EOAPI_SYNC_LIMIT")
+        self.EOAPI_STAC_API_GLOBAL = self.parse_base_url(
+            "EOAPI_STAC_API_GLOBAL", preserve_path=True, strip_path_trailing_slash=True
+        )
         self.GEOCODER_URL = self.parse_base_url_required("GEOCODER_URL")
         self.REQUESTS_PROXY_HOST = self.parse_proxy_url()
 

--- a/main/configs.py
+++ b/main/configs.py
@@ -177,10 +177,12 @@ class EtlConfig:
         # NOTE: Used by main/checks.py
         self.checks: list[CheckMessage] = []
 
-        self.EOAPI_STAC_API = self.parse_base_url("EOAPI_STAC_API", preserve_path=True, strip_path_trailing_slash=True)
+        self.EOAPI_STAC_API_INTERNAL = self.parse_base_url(
+            "EOAPI_STAC_API_INTERNAL", preserve_path=True, strip_path_trailing_slash=True
+        )
         self.EOAPI_SYNC_LIMIT = self.parse_int_value_required("EOAPI_SYNC_LIMIT")
-        self.EOAPI_STAC_API_GLOBAL = self.parse_base_url(
-            "EOAPI_STAC_API_GLOBAL", preserve_path=True, strip_path_trailing_slash=True
+        self.EOAPI_STAC_API_PUBLIC = self.parse_base_url(
+            "EOAPI_STAC_API_PUBLIC", preserve_path=True, strip_path_trailing_slash=True
         )
         self.GEOCODER_URL = self.parse_base_url_required("GEOCODER_URL")
         self.REQUESTS_PROXY_HOST = self.parse_proxy_url()

--- a/main/settings.py
+++ b/main/settings.py
@@ -86,9 +86,9 @@ env = environ.Env(
     # NOTE:
     # /stac is not required for internal service. eg: http://montandon-eoapi-stac.montandon-eoapi.svc.cluster.local:8080
     # /stac is required for external domain. eg:  https://montandon-eoapi-stage.monty.org/stac
-    EOAPI_STAC_API=(str, None),
+    EOAPI_STAC_API_INTERNAL=(str, None),
     EOAPI_SYNC_LIMIT=(int, 10000),
-    EOAPI_STAC_API_GLOBAL=(str, None),
+    EOAPI_STAC_API_PUBLIC=(str, None),
     REQUESTS_PROXY_TO_USE=(str, None),  # NOTE: For more detail look at ./README.md
     # Sources
     # FIXME: Check if all start dates are used
@@ -133,11 +133,11 @@ env = environ.Env(
 )
 
 
-EOAPI_STAC_API = env("EOAPI_STAC_API")
+EOAPI_STAC_API_INTERNAL = env("EOAPI_STAC_API_INTERNAL")
 EOAPI_SYNC_LIMIT = env("EOAPI_SYNC_LIMIT")
-# NOTE We add _GLOBAL field to be ingested within stac items
+# NOTE We add EOAPI_STAC_API_PUBLIC field to be ingested within stac items
 # so that the links can be accessed outside of cluster
-EOAPI_STAC_API_GLOBAL = env("EOAPI_STAC_API_GLOBAL")
+EOAPI_STAC_API_PUBLIC = env("EOAPI_STAC_API_PUBLIC")
 GEOCODER_URL = env("GEOCODER_URL")
 REQUESTS_PROXY_TO_USE = env("REQUESTS_PROXY_TO_USE")
 

--- a/main/settings.py
+++ b/main/settings.py
@@ -88,6 +88,7 @@ env = environ.Env(
     # /stac is required for external domain. eg:  https://montandon-eoapi-stage.monty.org/stac
     EOAPI_STAC_API=(str, None),
     EOAPI_SYNC_LIMIT=(int, 10000),
+    EOAPI_STAC_API_GLOBAL=(str, None),
     REQUESTS_PROXY_TO_USE=(str, None),  # NOTE: For more detail look at ./README.md
     # Sources
     # FIXME: Check if all start dates are used
@@ -134,6 +135,9 @@ env = environ.Env(
 
 EOAPI_STAC_API = env("EOAPI_STAC_API")
 EOAPI_SYNC_LIMIT = env("EOAPI_SYNC_LIMIT")
+# NOTE We add _GLOBAL field to be ingested within stac items
+# so that the links can be accessed outside of cluster
+EOAPI_STAC_API_GLOBAL = env("EOAPI_STAC_API_GLOBAL")
 GEOCODER_URL = env("GEOCODER_URL")
 REQUESTS_PROXY_TO_USE = env("REQUESTS_PROXY_TO_USE")
 


### PR DESCRIPTION
NOTE: **Mention related users here if any.**

## Changes

* use a different environment variable `EOAPI_STAC_API_GLOBAL` to be ingested in the stac items for the link fields
* use the env var `EOAPI_STAC_API_INTERNAL` for internal communication.

## This PR doesn't introduce any:

- [X] temporary files, auto-generated files or secret keys
- [X] n+1 queries
- [X] linter issues
- [X] `print`
- [X] typos
- [ ] unwanted comments

## This PR contains valid:

- [X] tests
