### PR TITLE
fix: pull the latest pdc object which is a success

### DIFF
--- a/apps/etl/etl_tasks/pdc.py
+++ b/apps/etl/etl_tasks/pdc.py
@@ -19,10 +19,15 @@ from main.configs import etl_config
 @shared_task
 def extract_and_transform_pdc_latest_data():
     data_url = f"{etl_config.PDC_SENTRY_BASE_URL}/hp_srv/services/hazards/t/json/search_hazard"
-    pdc_latest_extraction = ExtractionData.objects.filter(
-        source=ExtractionData.Source.PDC,
-        status=ExtractionData.Status.SUCCESS,
-    ).last()
+    pdc_latest_extraction = (
+        ExtractionData.objects.filter(
+            source=ExtractionData.Source.PDC,
+            status=ExtractionData.Status.SUCCESS,
+        )
+        .order_by("-id")
+        .first()
+    )
+
     if pdc_latest_extraction:
         created_at = pdc_latest_extraction.created_at.strftime("%Y-%m-%d %H:%M:%S.%f")
         start_date = datetime.strptime(created_at, "%Y-%m-%d %H:%M:%S.%f")


### PR DESCRIPTION
## Changes

* Fix on pulling the latest data of PDC with a "SUCCESS"

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] linter issues
- [x] `print`
- [x] typos
- [ ] unwanted comments

## This PR contains valid:

- [x] tests
