### PR TITLE
deps: migrate container images from Bitnami to Soldevelo equivalents

### DIFF
--- a/helm/snapshots/alpha-1.yaml
+++ b/helm/snapshots/alpha-1.yaml
@@ -2474,7 +2474,7 @@ spec:
       serviceAccountName: montandon-etl-minio
       initContainers:
         - name: wait-for-available-minio
-          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r35
+          image: docker.io/soldevelo/os-shell:12-debian-12-r3
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Dependency update: Bitnami to SolDevelo container images

Bitnami changed its container image distribution model on **August 28, 2025**, restricting access to many previously free images.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides free drop-in replacement images built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a maintained fork of `bitnami/containers`, published to Docker Hub under the `soldevelo/` namespace. Tags are kept in sync with upstream Bitnami.

This PR updates all affected image references in the repository.

## Changed images

- `bitnamilegacy/os-shell:12-debian-12-r35` → [`soldevelo/os-shell:12-debian-12-r3`](https://hub.docker.com/r/soldevelo/os-shell)